### PR TITLE
Force no-cache in vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# XMTP MiniApp with Next.js
+
+A Farcaster MiniApp with XMTP private chat example.
+
+## Getting Started
+
+This Farcaster Miniapp (Framev2) is a [Next.js](https://nextjs.org) project
+bootstrapped with the
+[`Builders Garden miniapp template`](https://github.com/builders-garden/miniapp-next-template),
+you can find more information about the template
+[here](https://frames-v2.builders.garden). For more information about Farcaster
+Miniapps, you can find more information [here](https://miniapps.farcaster.xyz/).
+
+## Prerequisites
+
+- Node.js >=20
+- Yarn @4.6.0 package manager
+- A Farcaster account on your phone
+
+## Development
+
+Start the frontend and backend servers:
+
+```bash
+cd frontend
+cp .env.example .env.local
+bun i
+bun run dev
+```
+
+```bash
+cd backend
+cp .env.example .env.local
+bun i
+bun run dev
+```

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -49,6 +49,39 @@ const nextConfig = {
   experimental: {
     serverComponentsExternalPackages: ["@xmtp/node-bindings"],
   },
+  // Disable all caching
+  onDemandEntries: {
+    // Make Next.js not keep pages in memory
+    maxInactiveAge: 0,
+  },
+  // Prevent static optimizations
+  swcMinify: true,
+  // Disable static generation
+  output: "standalone",
+  // Disable caching of static assets
+  staticPageGenerationTimeout: 0,
+  headers: async () => {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          {
+            key: "Cache-Control",
+            value:
+              "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0",
+          },
+          {
+            key: "Pragma",
+            value: "no-cache",
+          },
+          {
+            key: "Expires",
+            value: "0",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,11 +1,14 @@
 {
-  "name": "framesv2-nextjs-basic",
-  "version": "0.1.0",
+  "name": "xmtp-mini-app",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "scripts": {
     "build": "next build",
+    "build:no-cache": "yarn clear-cache && next build",
+    "clear-cache": "rm -rf .next/cache",
     "dev": "next dev",
+    "dev:no-cache": "yarn clear-cache && next dev",
     "format": "prettier --write .",
     "frames": "frames ",
     "lint": "next lint",

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /
+Cache-Control: no-cache, no-store, must-revalidate 

--- a/frontend/src/app/config.ts
+++ b/frontend/src/app/config.ts
@@ -1,0 +1,8 @@
+// This file sets global Next.js configurations to disable caching
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
+export const runtime = "edge";
+
+// Exporting these configurations makes them available for any route
+// that imports them or for the Next.js framework when placed in layout files

--- a/frontend/src/app/head.tsx
+++ b/frontend/src/app/head.tsx
@@ -1,0 +1,12 @@
+export default function Head() {
+  return (
+    <>
+      <meta
+        http-equiv="Cache-Control"
+        content="no-cache, no-store, must-revalidate"
+      />
+      <meta http-equiv="Pragma" content="no-cache" />
+      <meta http-equiv="Expires" content="0" />
+    </>
+  );
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -3,13 +3,25 @@ import type { Metadata } from "next";
 import { Montserrat } from "next/font/google";
 import { headers } from "next/headers";
 import { Providers } from "@/providers";
+import "./config"; // Import global config to disable caching
 
 const montserrat = Montserrat({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "XMTP MiniApp",
   description: "XMTP MiniApp",
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000",
+  ),
+  other: {
+    "Cache-Control":
+      "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0",
+    Pragma: "no-cache",
+    Expires: "0",
+  },
 };
+
+export const revalidate = 0;
 
 export default function RootLayout({
   children,

--- a/frontend/src/app/no-cache.ts
+++ b/frontend/src/app/no-cache.ts
@@ -1,0 +1,5 @@
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+// This is a utility file that can be imported in any page or layout where you want to ensure no caching
+// Usage: import '@/app/no-cache';

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -5,7 +5,9 @@ import { env } from "@/lib/env";
 import "@/app/no-cache";
 
 // Force dynamic rendering with no caching
-export const dynamicConfig = "force-dynamic";
+export const dynamicParams = false;
+export const runtime = "nodejs";
+export const fetchCache = "force-no-store";
 export const revalidate = 0;
 
 const HomePage = dynamic(() => import("@/components/pages/home"), {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2,6 +2,11 @@ import { Metadata } from "next";
 import dynamic from "next/dynamic";
 import { OG_IMAGE_SIZE } from "@/lib/constants";
 import { env } from "@/lib/env";
+import "@/app/no-cache";
+
+// Force dynamic rendering with no caching
+export const dynamicConfig = "force-dynamic";
+export const revalidate = 0;
 
 const HomePage = dynamic(() => import("@/components/pages/home"), {
   ssr: false,

--- a/frontend/src/components/pages/home/conversations-page.tsx
+++ b/frontend/src/components/pages/home/conversations-page.tsx
@@ -119,6 +119,7 @@ export default function ConversationsPage({
       const { groupId, isMember } = await getGroupId();
       console.log("groupId", groupId);
       console.log("isMember", isMember);
+      console.log("version", "1.1.1");
       console.log("Conversations count:", conversations.length);
 
       // IMPORTANT: Always set isGroupJoined based on isMember status from API

--- a/frontend/src/components/pages/home/conversations-page.tsx
+++ b/frontend/src/components/pages/home/conversations-page.tsx
@@ -119,7 +119,7 @@ export default function ConversationsPage({
       const { groupId, isMember } = await getGroupId();
       console.log("groupId", groupId);
       console.log("isMember", isMember);
-      console.log("version", "1.1.1");
+      console.log("version", "0.1.1");
       console.log("Conversations count:", conversations.length);
 
       // IMPORTANT: Always set isGroupJoined based on isMember status from API

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,29 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  // Clone the request headers
+  const requestHeaders = new Headers(request.headers);
+
+  // Get the response
+  const response = NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
+
+  // Set cache control headers to prevent caching
+  response.headers.set(
+    "Cache-Control",
+    "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0",
+  );
+  response.headers.set("Pragma", "no-cache");
+  response.headers.set("Expires", "0");
+  response.headers.set("Surrogate-Control", "no-store");
+
+  return response;
+}
+
+// Configure which paths to apply this middleware to
+export const config = {
+  matcher: "/((?!api/.|_next/static|_next/image|favicon.ico).*)",
+};

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,25 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0"
+        },
+        {
+          "key": "Pragma",
+          "value": "no-cache"
+        },
+        {
+          "key": "Expires",
+          "value": "0"
+        },
+        {
+          "key": "Surrogate-Control",
+          "value": "no-store"
+        }
+      ]
+    }
+  ]
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5730,63 +5730,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"framesv2-nextjs-basic@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "framesv2-nextjs-basic@workspace:."
-  dependencies:
-    "@farcaster/frame-core": "npm:^0.0.31"
-    "@farcaster/frame-node": "npm:^0.0.20"
-    "@farcaster/frame-sdk": "npm:^0.0.34"
-    "@farcaster/frame-wagmi-connector": "npm:^0.0.22"
-    "@frames.js/debugger": "npm:0.5.0"
-    "@ianvs/prettier-plugin-sort-imports": "npm:^4.4.1"
-    "@radix-ui/react-dialog": "npm:^1.1.7"
-    "@radix-ui/react-popover": "npm:^1.1.6"
-    "@radix-ui/react-scroll-area": "npm:^1.2.3"
-    "@radix-ui/react-slot": "npm:^1.1.2"
-    "@t3-oss/env-nextjs": "npm:^0.12.0"
-    "@tanstack/react-query": "npm:^5.69.0"
-    "@types/localtunnel": "npm:^2"
-    "@types/node": "npm:^20"
-    "@types/react": "npm:^18"
-    "@types/react-dom": "npm:^18"
-    "@vercel/og": "npm:^0.6.5"
-    "@xmtp/browser-sdk": "npm:^2.0.8"
-    class-variance-authority: "npm:^0.7.1"
-    clsx: "npm:^2.1.1"
-    dotenv: "npm:^16.4.7"
-    eruda: "npm:^3.4.1"
-    eslint: "npm:^8"
-    eslint-config-next: "npm:14.2.6"
-    eslint-config-prettier: "npm:^10.0.1"
-    eslint-plugin-prettier: "npm:^5.2.3"
-    framer-motion: "npm:^12.4.12"
-    jiti: "npm:1.21.7"
-    jose: "npm:^6.0.10"
-    ky: "npm:^1.7.5"
-    localtunnel: "npm:^2.0.2"
-    lucide-react: "npm:^0.483.0"
-    next: "npm:14.2.6"
-    prettier: "npm:^3.4.2"
-    prettier-plugin-packagejson: "npm:^2.5.8"
-    react: "npm:^18"
-    react-dom: "npm:^18"
-    react-number-format: "npm:^5.4.3"
-    tailwind-merge: "npm:^3.0.2"
-    tailwindcss: "npm:^3.4.1"
-    tailwindcss-animate: "npm:^1.0.7"
-    typescript: "npm:^5"
-    uint8array-extras: "npm:^1.4.0"
-    uint8arrays: "npm:^5.1.0"
-    usehooks-ts: "npm:^3.1.1"
-    uuid: "npm:^11.1.0"
-    vaul: "npm:^1.1.2"
-    viem: "npm:^2.26.2"
-    wagmi: "npm:^2.14.15"
-    zod: "npm:^3.24.2"
-  languageName: unknown
-  linkType: soft
-
 "fs-constants@npm:^1.0.0":
   version: 1.0.0
   resolution: "fs-constants@npm:1.0.0"
@@ -10559,6 +10502,63 @@ __metadata:
   checksum: 10/708a177fe41c6c8cd4ec7c04d965b4c01801d87f44383ec639be58bdc14418142969841659e0850db44feee8bec0a3d3e7d33fed22519415f3d0daab04d3f160
   languageName: node
   linkType: hard
+
+"xmtp-mini-app@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "xmtp-mini-app@workspace:."
+  dependencies:
+    "@farcaster/frame-core": "npm:^0.0.31"
+    "@farcaster/frame-node": "npm:^0.0.20"
+    "@farcaster/frame-sdk": "npm:^0.0.34"
+    "@farcaster/frame-wagmi-connector": "npm:^0.0.22"
+    "@frames.js/debugger": "npm:0.5.0"
+    "@ianvs/prettier-plugin-sort-imports": "npm:^4.4.1"
+    "@radix-ui/react-dialog": "npm:^1.1.7"
+    "@radix-ui/react-popover": "npm:^1.1.6"
+    "@radix-ui/react-scroll-area": "npm:^1.2.3"
+    "@radix-ui/react-slot": "npm:^1.1.2"
+    "@t3-oss/env-nextjs": "npm:^0.12.0"
+    "@tanstack/react-query": "npm:^5.69.0"
+    "@types/localtunnel": "npm:^2"
+    "@types/node": "npm:^20"
+    "@types/react": "npm:^18"
+    "@types/react-dom": "npm:^18"
+    "@vercel/og": "npm:^0.6.5"
+    "@xmtp/browser-sdk": "npm:^2.0.8"
+    class-variance-authority: "npm:^0.7.1"
+    clsx: "npm:^2.1.1"
+    dotenv: "npm:^16.4.7"
+    eruda: "npm:^3.4.1"
+    eslint: "npm:^8"
+    eslint-config-next: "npm:14.2.6"
+    eslint-config-prettier: "npm:^10.0.1"
+    eslint-plugin-prettier: "npm:^5.2.3"
+    framer-motion: "npm:^12.4.12"
+    jiti: "npm:1.21.7"
+    jose: "npm:^6.0.10"
+    ky: "npm:^1.7.5"
+    localtunnel: "npm:^2.0.2"
+    lucide-react: "npm:^0.483.0"
+    next: "npm:14.2.6"
+    prettier: "npm:^3.4.2"
+    prettier-plugin-packagejson: "npm:^2.5.8"
+    react: "npm:^18"
+    react-dom: "npm:^18"
+    react-number-format: "npm:^5.4.3"
+    tailwind-merge: "npm:^3.0.2"
+    tailwindcss: "npm:^3.4.1"
+    tailwindcss-animate: "npm:^1.0.7"
+    typescript: "npm:^5"
+    uint8array-extras: "npm:^1.4.0"
+    uint8arrays: "npm:^5.1.0"
+    usehooks-ts: "npm:^3.1.1"
+    uuid: "npm:^11.1.0"
+    vaul: "npm:^1.1.2"
+    viem: "npm:^2.26.2"
+    wagmi: "npm:^2.14.15"
+    zod: "npm:^3.24.2"
+  languageName: unknown
+  linkType: soft
 
 "xtend@npm:^4.0.1":
   version: 4.0.2


### PR DESCRIPTION
### Disable caching throughout Next.js application to ensure accurate version tracking in conversations page
Implements comprehensive caching prevention across the Next.js application through multiple layers:

* Adds configuration in [next.config.mjs](https://github.com/ephemeraHQ/xmtp-mini-app/pull/14/files#diff-00069db1d185a39243c53234cfe30f0e1eb32f68fde492c378783f249fae108d) to disable server-side caching and static optimization
* Creates new [config.ts](https://github.com/ephemeraHQ/xmtp-mini-app/pull/14/files#diff-e237223c5c2589ddfcdfad812db21a3d975c3f072928c5cbc3f224ff870739d4) and [no-cache.ts](https://github.com/ephemeraHQ/xmtp-mini-app/pull/14/files#diff-a3f52ebbe0f356e0179ea96c750b18f511eb90d0081e1c775d031b244796e82a) utilities exporting Next.js settings for dynamic rendering
* Implements [middleware.ts](https://github.com/ephemeraHQ/xmtp-mini-app/pull/14/files#diff-c97d84b7bce6d5239ff87ac5694ad83d8aee62fcb23fbf6870be5bd08a5222ac) to inject cache control headers for all non-static routes
* Adds version logging (v0.1.1) in [conversations-page.tsx](https://github.com/ephemeraHQ/xmtp-mini-app/pull/14/files#diff-778379f3dc6d00d7b2a030e853c5b40f39a3bbdcf89b4fe8be97df308bd8d8c8) and refactors `handleFetchGroupId` using `useCallback`
* Configures cache prevention headers in [vercel.json](https://github.com/ephemeraHQ/xmtp-mini-app/pull/14/files#diff-252c054dd384dcb5efedd1f35db1e996c896cb5c110b2919521530433b6d824e) for deployment

#### 📍Where to Start
Start with the Next.js configuration changes in [next.config.mjs](https://github.com/ephemeraHQ/xmtp-mini-app/pull/14/files#diff-00069db1d185a39243c53234cfe30f0e1eb32f68fde492c378783f249fae108d) which establishes the base caching prevention settings, then review the cache control implementation in [middleware.ts](https://github.com/ephemeraHQ/xmtp-mini-app/pull/14/files#diff-c97d84b7bce6d5239ff87ac5694ad83d8aee62fcb23fbf6870be5bd08a5222ac).

----

_[Macroscope](https://app.macroscope.com) summarized 4117934._