### PR TITLE
Rename OnchainKitSigner to SCWSigner for clarity

### DIFF
--- a/frontend/.cursor/rules/xmtp-web.md
+++ b/frontend/.cursor/rules/xmtp-web.md
@@ -8,7 +8,7 @@
 - Select the right signer for your authentication method:
   - `createEOASigner` for standard wallet authentication
   - `createEphemeralSigner` for temporary sessions
-  - `createOnchainKitSigner` for smart contract wallets
+  - `createSCWSigner` for smart contract wallets
 - Implement comprehensive error handling around client initialization
 - Add timeout handling for signature requests to prevent UI freezes
 - Store authentication state securely in localStorage with proper encryption
@@ -29,7 +29,7 @@ const client = await Client.create(signer, {
 - Create appropriate signers based on wallet type:
   - Use `createEOASigner` for EOA wallets (MetaMask, WalletConnect)
   - Use `createEphemeralSigner` for temporary sessions or testing
-  - Use `createOnchainKitSigner` for smart contract wallets
+  - Use `createSCWSigner` for smart contract wallets
 - Ensure signers implement the complete `Signer` interface
 - Include `getChainId` method for smart contract wallet signers
 - Verify wallet connection before signer creation
@@ -40,7 +40,7 @@ const client = await Client.create(signer, {
 const signer = createEOASigner(walletClient.account.address, walletClient);
 
 // Smart Contract Wallet signer implementation
-const signer = createOnchainKitSigner(
+const signer = createSCWSigner(
   walletClient.account.address,
   signMessageAsync,
   BigInt(chainId)

--- a/frontend/.cursor/rules/xmtp-web.mdc
+++ b/frontend/.cursor/rules/xmtp-web.mdc
@@ -13,7 +13,7 @@ alwaysApply: true
 - Select the right signer for your authentication method:
   - `createEOASigner` for standard wallet authentication
   - `createEphemeralSigner` for temporary sessions
-  - `createOnchainKitSigner` for smart contract wallets
+  - `createSCWSigner` for smart contract wallets
 - Implement comprehensive error handling around client initialization
 - Add timeout handling for signature requests to prevent UI freezes
 - Store authentication state securely in localStorage with proper encryption
@@ -34,7 +34,7 @@ const client = await Client.create(signer, {
 - Create appropriate signers based on wallet type:
   - Use `createEOASigner` for EOA wallets (MetaMask, WalletConnect)
   - Use `createEphemeralSigner` for temporary sessions or testing
-  - Use `createOnchainKitSigner` for smart contract wallets
+  - Use `createSCWSigner` for smart contract wallets
 - Ensure signers implement the complete `Signer` interface
 - Include `getChainId` method for smart contract wallet signers
 - Verify wallet connection before signer creation
@@ -45,7 +45,7 @@ const client = await Client.create(signer, {
 const signer = createEOASigner(walletClient.account.address, walletClient);
 
 // Smart Contract Wallet signer implementation
-const signer = createOnchainKitSigner(
+const signer = createSCWSigner(
   walletClient.account.address,
   signMessageAsync,
   BigInt(chainId)

--- a/frontend/src/examples/WalletConnection.tsx
+++ b/frontend/src/examples/WalletConnection.tsx
@@ -10,7 +10,7 @@ import { Button } from "@/components/Button";
 import { useXMTP } from "@/context/xmtp-context";
 import { env } from "@/lib/env";
 import { useSignMessage } from "wagmi";
-import {  createEphemeralSigner, createEOASigner, createOnchainKitSigner } from "@/lib/xmtp";
+import {  createEphemeralSigner, createEOASigner, createSCWSigner } from "@/lib/xmtp";
 
 // Simple local storage keys
 const XMTP_CONNECTION_TYPE_KEY = "xmtp:connectionType";
@@ -50,7 +50,7 @@ export default function WalletConnection() {
     } 
     
     if (connectionType === "Coinbase Smart Wallet" && connector?.id === 'coinbaseWalletSDK') {
-      return createOnchainKitSigner(
+      return createSCWSigner(
         walletData.account.address,
         signMessageAsync,
         BigInt(mainnet.id)

--- a/frontend/src/lib/xmtp.ts
+++ b/frontend/src/lib/xmtp.ts
@@ -81,7 +81,7 @@ export const createEOASigner = (
 
 
 
-export const createOnchainKitSigner = (   
+export const createSCWSigner = (   
   address: `0x${string}`,
   signMessageAsync: (args: { message: string }) => Promise<`0x${string}`>,
   chainId: bigint | number = 1,


### PR DESCRIPTION
### Rename `createOnchainKitSigner` function to `createSCWSigner` for clarity in XMTP web documentation and implementation
Updates function naming across documentation and implementation files:

* Renames `createOnchainKitSigner` to `createSCWSigner` in documentation within [xmtp-web.md](https://github.com/ephemeraHQ/xmtp-mini-app-examples/pull/32/files#diff-06a903d0898a38384a973a5aa05df1ac8411546870a240f40979dc31d01ed099) and [xmtp-web.mdc](https://github.com/ephemeraHQ/xmtp-mini-app-examples/pull/32/files#diff-902b9c2b386efa967e0d0e064340c769bbf9e7c5898aa4fd23999bf276ce3341)
* Updates import statement and function call in [WalletConnection.tsx](https://github.com/ephemeraHQ/xmtp-mini-app-examples/pull/32/files#diff-9ea7fd96922a487ef73be8a4f1c16cc08d39b44be3a0f7c9000766ee9f90ac90)
* Renames function declaration in [xmtp.ts](https://github.com/ephemeraHQ/xmtp-mini-app-examples/pull/32/files#diff-60406a69e0a7dcf72df66fd14c77f00126d083e032dd7f51a1cae0919268b05d) while maintaining identical implementation

#### 📍Where to Start
Start with the function declaration in [xmtp.ts](https://github.com/ephemeraHQ/xmtp-mini-app-examples/pull/32/files#diff-60406a69e0a7dcf72df66fd14c77f00126d083e032dd7f51a1cae0919268b05d) which contains the core implementation, then follow usage in [WalletConnection.tsx](https://github.com/ephemeraHQ/xmtp-mini-app-examples/pull/32/files#diff-9ea7fd96922a487ef73be8a4f1c16cc08d39b44be3a0f7c9000766ee9f90ac90)

----

_[Macroscope](https://app.macroscope.com) summarized c14e3f8._