### PR TITLE
Refactor GroupManagement layout for better readability

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -283,7 +283,7 @@ app.get(
           : null;
 
         const responseObject = {
-          groupId: process.env.GROUP_ID, 
+          groupId: process.env.GROUP_ID,
           groupName: (conversation as Group).name,
           isMember,
           memberCount: groupMembers.length,

--- a/frontend/src/examples/GroupChat.tsx
+++ b/frontend/src/examples/GroupChat.tsx
@@ -256,25 +256,7 @@ export default function GroupManagement() {
             </span>
           </p>
         </div>
-        <Button
-          className="w-full mt-3"
-          size="sm"
-          onClick={isGroupJoined ? handleLeaveGroup : handleJoinGroup}
-          disabled={joining || isRefreshing || !client}>
-          {joining ? "Processing..." : isRefreshing ? "Refreshing..." : isGroupJoined ? "Leave Group" : "Join Group Chat"}
-        </Button>
-      </div>
-
-      {/* Group Chat Section - Only show when in a group */}
-      {client && isGroupJoined  && (
-        <div className="w-full bg-gray-900 p-3 rounded-md">
-          <div className="flex justify-between items-center">
-            <h2 className="text-white text-sm font-medium">Group Chat</h2>
-            <span className="text-gray-400 text-xs">
-              {groupName || "XMTP Group"}
-            </span>
-          </div>
-          
+        {client && isGroupJoined && (
           <div className="mt-3">
             <div className="relative">
               <input
@@ -301,8 +283,18 @@ export default function GroupManagement() {
               </div>
             )}
           </div>
-        </div>
-      )}
+        )}
+
+       <Button
+          className="w-full mt-3"
+          size="sm"
+          onClick={isGroupJoined ? handleLeaveGroup : handleJoinGroup}
+          disabled={joining || isRefreshing || !client}>
+          {joining ? "Processing..." : isRefreshing ? "Refreshing..." : isGroupJoined ? "Leave Group" : "Join Group Chat"}
+        </Button>
+      </div>
+
+     
     </div>
   );
 }


### PR DESCRIPTION
### Reorganize GroupChat component layout to integrate chat functionality within group information section
* Restructures UI layout in [GroupChat.tsx](https://github.com/ephemeraHQ/xmtp-mini-app-examples/pull/34/files#diff-45ce04a8b74054419c93789bc292508f5845b4be32703acddb0ada56015203dc) to move chat input and message display into the group information section, positioning them above the join/leave button
* Removes trailing whitespace from `groupId` property in [index.ts](https://github.com/ephemeraHQ/xmtp-mini-app-examples/pull/34/files#diff-c20200a666b149a045e365999f581db8e04687cfc9569bdf4c9477cab954d324)

#### 📍Where to Start
Start with the UI layout changes in the `GroupChat` component in [GroupChat.tsx](https://github.com/ephemeraHQ/xmtp-mini-app-examples/pull/34/files#diff-45ce04a8b74054419c93789bc292508f5845b4be32703acddb0ada56015203dc), which contains the main structural modifications.

----

_[Macroscope](https://app.macroscope.com) summarized 7ddb17b._